### PR TITLE
Fix type mismatch in mountPlugin

### DIFF
--- a/src/mountPlugin.ts
+++ b/src/mountPlugin.ts
@@ -1,12 +1,15 @@
 import type { SvelteComponent } from 'svelte';
-import { ShapeType, type ImageAnnotator } from '@annotorious/annotorious';
+import { ShapeType, type ImageAnnotator, type ImageAnnotation, type Annotation } from '@annotorious/annotorious';
 import type { OpenSeadragonAnnotator } from '@annotorious/openseadragon';
 import { EllipseEditor, RubberbandEllipse } from './ellipse';
 import { LineEditor, RubberbandLine } from './line';
 import { RubberbandPath, PathEditor } from './path';
 
-export const mountPlugin = (
-  anno: ImageAnnotator | OpenSeadragonAnnotator
+export const mountPlugin = <
+  I extends Annotation = ImageAnnotation,
+  E extends unknown = ImageAnnotation,
+>(
+  anno: ImageAnnotator<I, E> | OpenSeadragonAnnotator<I, E>
 ) => {
   anno.registerDrawingTool('ellipse', RubberbandEllipse as typeof SvelteComponent);
   anno.registerShapeEditor(ShapeType.ELLIPSE, EllipseEditor as typeof SvelteComponent);


### PR DESCRIPTION
This PR updates the `mountPlugin` helper to be generic over annotation types.
It allows both `ImageAnnotator` and `OpenSeadragonAnnotator` instances with custom type parameters (e.g. `W3CImageAnnotation`) to be passed without causing TypeScript errors.

Closes #7 